### PR TITLE
Fix runner selection

### DIFF
--- a/kubiya_workflow_sdk/client.py
+++ b/kubiya_workflow_sdk/client.py
@@ -457,15 +457,13 @@ class KubiyaClient:
         if parameters:
             workflow_definition["parameters"] = parameters
 
+        # Use the runner from the workflow definition if specified, otherwise use default
+        runner = workflow_definition.pop('runner', self.runner)
         # Prepare request body - workflow fields at top level
         request_body = {**workflow_definition}  # Spread workflow fields at top level
 
         logger.info("Executing workflow...")
         logger.debug(f"Request body: {json.dumps(request_body, indent=2)}")
-
-        # Use the runner from the workflow definition if specified, otherwise use default
-        runner = workflow_definition.get("runner", self.runner)
-        del request_body["runner"]
 
         # Execute the workflow
         endpoint = f"/api/v1/workflow?runner={runner}&operation=execute_workflow"


### PR DESCRIPTION
Such code fails in case when I don't pass `"runner"` into Workflow definition:

```python
from kubiya_workflow_sdk import execute_workflow

# I do not pass "runner" into Workflow definition
workflow_definition = {"name": "...", steps: [...]}

# Some custom config class with parameters
config = Config(...)

for line in execute_workflow(
    workflow_definition=workflow_definition,
    api_key=config.KUBIYA_API_KEY,
    runner=config.runner,
):
    print(line)
```